### PR TITLE
Add API Key Management

### DIFF
--- a/Sources/Resend/Models/Request/APIKey/APIKeyCreate.swift
+++ b/Sources/Resend/Models/Request/APIKey/APIKeyCreate.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct APIKeyCreate: Encodable {
+    var name: String
+    var permission: String
+    var domainId: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case name
+        case permission
+        case domainId = "domain_id"
+    }
+} 

--- a/Sources/Resend/Models/Response/APIKey/APIKeyCreateResponse.swift
+++ b/Sources/Resend/Models/Response/APIKey/APIKeyCreateResponse.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public struct APIKeyCreateResponse: Decodable {
+    public var id: String
+    public var token: String
+} 

--- a/Sources/Resend/Models/Response/APIKey/APIKeyListResponse.swift
+++ b/Sources/Resend/Models/Response/APIKey/APIKeyListResponse.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public struct APIKeyListResponse: Decodable {
+    public var data: [APIKey]
+}
+
+public struct APIKey: Decodable {
+    public var id: String
+    public var name: String
+    public var createdAt: Date
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case createdAt = "created_at"
+    }
+} 

--- a/Sources/Resend/Resend/APIKeyClient.swift
+++ b/Sources/Resend/Resend/APIKeyClient.swift
@@ -1,0 +1,52 @@
+import AsyncHTTPClient
+import NIOHTTP1
+
+public class APIKeyClient: ResendClient {
+    
+    internal override init(httpClient: HTTPClient, apiKey: String) {
+        super.init(httpClient: httpClient, apiKey: apiKey)
+    }
+    
+    /// Create a new API key
+    public func create(name: String, permission: String, domainId: String? = nil) async throws -> APIKeyCreateResponse {
+        let body = APIKeyCreate(name: name, permission: permission, domainId: domainId)
+        let response = try await httpClient.execute(
+            request: .init(
+                url: APIPath.getPath(for: .apiKeyCreate),
+                method: .POST,
+                headers: getAuthHeader(),
+                body: .data(encoder.encode(body))
+            )
+        ).get()
+        
+        return try parseResponse(response, to: APIKeyCreateResponse.self)
+    }
+    
+    /// List all API keys
+    public func list() async throws -> [APIKey] {
+        let response = try await httpClient.execute(
+            request: .init(
+                url: APIPath.getPath(for: .apiKeyList),
+                method: .GET,
+                headers: getAuthHeader()
+            )
+        ).get()
+        
+        return try parseResponse(response, to: APIKeyListResponse.self).data
+    }
+    
+    /// Delete an API key
+    public func delete(apiKeyId: String) async throws {
+        let response = try await httpClient.execute(
+            request: .init(
+                url: APIPath.getPath(for: .apiKeyDelete(apiKeyId: apiKeyId)),
+                method: .DELETE,
+                headers: getAuthHeader()
+            )
+        ).get()
+        
+        guard response.status == .ok else {
+            throw ResendError.unknownError
+        }
+    }
+} 

--- a/Sources/Resend/Resend/APIPath.swift
+++ b/Sources/Resend/Resend/APIPath.swift
@@ -25,6 +25,9 @@ enum APIPath {
     case contactUpdate(contactId: String, audienceId: String)
     case contactDelete(contactIdOrEmail: String, audienceId: String)
     case contactList(audienceId: String)
+    case apiKeyCreate
+    case apiKeyList
+    case apiKeyDelete(apiKeyId: String)
     
     private static func path(of path: String) -> String {
         APIPath.apiURL + path
@@ -56,6 +59,12 @@ enum APIPath {
             return path(of: "/audiences/\(audienceId)/contacts/\(contactIdOrEmail)")
         case .contactList(let audienceId):
             return path(of: "/audiences/\(audienceId)/contacts")
+        case .apiKeyCreate:
+            return path(of: "/api-keys")
+        case .apiKeyList:
+            return path(of: "/api-keys")
+        case .apiKeyDelete(let apiKeyId):
+            return path(of: "/api-keys/\(apiKeyId)")
         }
     }
 }

--- a/Sources/Resend/Resend/ResendClient.swift
+++ b/Sources/Resend/Resend/ResendClient.swift
@@ -54,6 +54,10 @@ public class ResendClient {
         ContactClient(httpClient: httpClient, apiKey: apiKey)
     }    
     
+    public var apiKeys: APIKeyClient {
+        APIKeyClient(httpClient: httpClient, apiKey: apiKey)
+    }
+    
     func parseResponse<T: Decodable>(_ response: HTTPClient.Response, to: T.Type) throws -> T {
         let byteBuffer: ByteBuffer = response.body ?? .init()
         

--- a/Tests/SwiftResendTests/SwiftResendTests.swift
+++ b/Tests/SwiftResendTests/SwiftResendTests.swift
@@ -257,4 +257,26 @@ final class SwiftResendTests: XCTestCase {
         }
     }
 
+    // MARK: API Key Tests
+    func testCreateAPIKey() async throws {
+        let response = try await resend.apiKeys.create(name: "Test Key", permission: "full_access")
+        XCTAssertNotNil(response.id)
+        XCTAssertNotNil(response.token)
+    }
+    
+    func testListAPIKeys() async throws {
+        let keys = try await resend.apiKeys.list()
+        XCTAssertGreaterThan(keys.count, 0)
+    }
+    
+    func testDeleteAPIKey() async throws {
+        let keys = try await resend.apiKeys.list()
+        guard let key = keys.first else {
+            XCTFail("No API keys to delete")
+            return
+        }
+        
+        try await resend.apiKeys.delete(apiKeyId: key.id)
+    }
+
 }


### PR DESCRIPTION
This PR adds API Key management to the `swift-resend` library, letting users create, list, and delete API keys with ease. It introduces the `APIKeyClient` class to handle these actions and includes new models for handling API key requests and responses. 