### PR TITLE
Fix Build Compatibility for Swift 6.0 and 5.10

### DIFF
--- a/Sources/Resend/Resend/EmailClient.swift
+++ b/Sources/Resend/Resend/EmailClient.swift
@@ -90,7 +90,7 @@ public class EmailClient: ResendClient {
             request: .init(
                 url: APIPath.getPath(for: .cancleSchedule(emailId: emailId)),
                 method: .POST,
-                headers: getAuthHeader(),
+                headers: getAuthHeader()
             )
         ).get()
         let canceledEmail = try parseResponse(response, to: EmailSentResponse.self)


### PR DESCRIPTION
This PR addresses a minor source compatibility issue that was preventing successful builds with Swift 6.0 and Swift 5.10. 

**Changes:**

* Fixed a method chaining line in `EmailClient.swift` to conform to updated Swift syntax rules.

This update is purely syntactic and does not impact runtime behavior.

- https://swiftpackageindex.com/builds/9A78262C-63D9-471A-BBD7-E0A5267E2DE4
- https://swiftpackageindex.com/builds/3DB8F7E7-579D-414F-879B-E27F9C82E59F
